### PR TITLE
Add file based backing store for preferences

### DIFF
--- a/protege-launcher/.gitignore
+++ b/protege-launcher/.gitignore
@@ -1,0 +1,1 @@
+.fileprefs

--- a/protege-launcher/.gitignore
+++ b/protege-launcher/.gitignore
@@ -1,1 +1,1 @@
-.fileprefs
+*.fileprefs

--- a/protege-launcher/src/main/java/org/protege/osgi/framework/Launcher.java
+++ b/protege-launcher/src/main/java/org/protege/osgi/framework/Launcher.java
@@ -16,6 +16,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.prefs.Preferences;
 
 
 public class Launcher {
@@ -44,6 +45,8 @@ public class Launcher {
 
 
     public Launcher(File config) throws IOException, ParserConfigurationException, SAXException {
+    	// call preferences userRoot() to force factory to load before OSGI
+    	Preferences.userRoot();
         parseConfig(config);
         factoryClass = locateOSGi();
         frameworkDir = new File(System.getProperty("java.io.tmpdir"), "ProtegeCache-" + UUID.randomUUID().toString());

--- a/protege-launcher/src/main/java/org/protege/prefs/FileBackingStorePrefsFactory.java
+++ b/protege-launcher/src/main/java/org/protege/prefs/FileBackingStorePrefsFactory.java
@@ -1,0 +1,45 @@
+package org.protege.prefs;
+
+import java.io.File;
+import java.util.prefs.Preferences;
+import java.util.prefs.PreferencesFactory;	
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileBackingStorePrefsFactory implements PreferencesFactory {
+	
+	private static final Logger log = LoggerFactory.getLogger(FileBackingStorePrefsFactory.class);
+	 
+	  Preferences rootPreferences;
+	  public static final String SYSTEM_PROPERTY_FILE =
+	    "org.protege.prefs.PrefsFactory.file";
+	 
+	  public Preferences systemRoot() {
+	    return userRoot();
+	  }
+	 
+	  public synchronized Preferences userRoot() {
+	    if (rootPreferences == null) {
+	      log.info("Instantiating root preferences");	 
+	      rootPreferences = new FilePrefs(null, "");
+	    }
+	    return rootPreferences;
+	  }
+	 
+	  private static File preferencesFile;
+	 
+	  public static synchronized File getPreferencesFile() {
+	    if (preferencesFile == null) {
+	      String prefsFile = System.getProperty(SYSTEM_PROPERTY_FILE);
+	      if (prefsFile == null || prefsFile.length() == 0) {
+	        prefsFile = ".fileprefs";
+	      }
+	      preferencesFile = new File(prefsFile).getAbsoluteFile();
+	      log.info("Preferences file is " + preferencesFile);
+	    }
+	    return preferencesFile;
+	  }
+
+
+}

--- a/protege-launcher/src/main/java/org/protege/prefs/FilePrefs.java
+++ b/protege-launcher/src/main/java/org/protege/prefs/FilePrefs.java
@@ -1,0 +1,192 @@
+package org.protege.prefs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.prefs.AbstractPreferences;
+import java.util.prefs.BackingStoreException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FilePrefs extends AbstractPreferences {
+	 private static final Logger log = LoggerFactory.getLogger(FilePrefs.class);
+	 
+	  private Map<String, String> root;
+	  private Map<String, FilePrefs> children;
+	  private List<String> children_names;
+	  private boolean isRemoved = false;
+	 
+	  public FilePrefs(AbstractPreferences parent, String name) {
+	    super(parent, name);
+	 
+	    log.info("Instantiating node " + name);
+	 
+	    root = new TreeMap<String, String>();
+	    children = new TreeMap<String, FilePrefs>();
+	    children_names = new ArrayList<String>();
+	 
+	    try {
+	      sync();
+	    }
+	    catch (BackingStoreException e) {
+	      log.error("Unable to sync on creation of node " + name, e);
+	    }
+	  }
+	 
+	  synchronized protected void putSpi(String key, String value) {
+	    root.put(key, value);
+	    try {
+	      flush();
+	    }
+	    catch (BackingStoreException e) {
+	      log.error("Unable to flush after putting " + key, e);
+	    }
+	  }
+	 
+	  synchronized protected String getSpi(String key) {
+	    return root.get(key);
+	  }
+	 
+	  synchronized protected void removeSpi(String key) {
+	    root.remove(key);
+	    try {
+	      flush();
+	    }
+	    catch (BackingStoreException e) {
+	      log.error("Unable to flush after removing " + key, e);
+	    }
+	  }
+	 
+	  synchronized protected void removeNodeSpi() throws BackingStoreException {
+	    isRemoved = true;
+	    flush();
+	  }
+	 
+	  synchronized protected String[] keysSpi() throws BackingStoreException {
+	    return root.keySet().toArray(new String[root.keySet().size()]);
+	  }
+	 
+	  synchronized protected String[] childrenNamesSpi() throws BackingStoreException {
+		  return children_names.toArray(new String[children_names.size()]);
+	  }
+	 
+	  synchronized protected FilePrefs childSpi(String name) {
+	    FilePrefs child = children.get(name);
+	    if (child == null || child.isRemoved()) {
+	      child = new FilePrefs(this, name);
+	      children.put(name, child);
+	    }
+	    return child;
+	  }
+	 
+	 
+	  protected synchronized void syncSpi() throws BackingStoreException {
+		  
+		  if (isRemoved()) return;
+
+		  final File file = FileBackingStorePrefsFactory.getPreferencesFile();
+
+		  if (!file.exists()) return;
+
+		  Properties p = new Properties();
+		  try {
+			  p.load(new FileInputStream(file));
+
+			  StringBuilder sb = new StringBuilder();
+			  getPath(sb);
+			  String path = sb.toString();
+
+			  final Enumeration<?> pnen = p.propertyNames();
+			  while (pnen.hasMoreElements()) {
+				  String propKey = (String) pnen.nextElement();
+				  if (propKey.startsWith(path)) {
+					  String subKey = propKey.substring(path.length());
+					  // Only load immediate descendents
+					  if (subKey.indexOf('/') == -1) {
+						  root.put(subKey, p.getProperty(propKey));
+					  } else {
+						  children_names.add(subKey.substring(0,subKey.indexOf('/')));
+					  }
+				  }
+			  }
+		  }
+		  catch (IOException e) {
+			  throw new BackingStoreException(e);
+		  }
+	  }
+	  
+	 
+	  private void getPath(StringBuilder sb) {
+	    final FilePrefs parent = (FilePrefs) parent();
+	    if (parent == null) return;
+	 
+	    parent.getPath(sb);
+	    sb.append(name()).append('/');
+	  }
+	 
+	  protected synchronized void flushSpi() throws BackingStoreException {
+		  
+		  final File file = FileBackingStorePrefsFactory.getPreferencesFile();
+		  
+		  try {
+
+			  StringBuilder sb = new StringBuilder();
+			  getPath(sb);
+			  String path = sb.toString();
+			  Properties p = new Properties();
+			  if (file.exists()) {
+				  
+				  p.load(new FileInputStream(file));
+
+				  List<String> toRemove = new ArrayList<String>();
+
+				  // Make a list of all direct children of this node to be removed
+				  final Enumeration<?> pnen = p.propertyNames();
+				  while (pnen.hasMoreElements()) {
+					  String propKey = (String) pnen.nextElement();
+					  if (propKey.startsWith(path)) {
+						  String subKey = propKey.substring(path.length());
+						  // Only do immediate descendants
+						  if (subKey.indexOf('/') == -1) {
+							  toRemove.add(propKey);
+						  }
+					  }
+				  }
+
+				  // Remove them now that the enumeration is done with
+				  for (String propKey : toRemove) {
+					  p.remove(propKey);
+				  }
+
+
+				  // If this node hasn't been removed, add back in any values
+				  if (!isRemoved) {
+					  for (String s : root.keySet()) {
+						  //System.out.println("Adding  " + s);
+						  p.setProperty(path + s, root.get(s));
+					  }
+				  }
+				  
+			  }
+			  if (p.size() > 0) {
+				  p.store(new FileOutputStream(file), "FilePreferences");
+			  } else {
+				  log.warn("what happened");
+				  p.store(new FileOutputStream(file), "FilePreferences");
+				  log.warn("wrote empty file");
+			  }
+		  }
+		  catch (IOException e) {
+			  throw new BackingStoreException(e);
+		  }
+	  }
+
+}

--- a/protege-launcher/src/main/java/org/protege/prefs/FilePrefs.java
+++ b/protege-launcher/src/main/java/org/protege/prefs/FilePrefs.java
@@ -17,176 +17,176 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FilePrefs extends AbstractPreferences {
-	 private static final Logger log = LoggerFactory.getLogger(FilePrefs.class);
-	 
-	  private Map<String, String> root;
-	  private Map<String, FilePrefs> children;
-	  private List<String> children_names;
-	  private boolean isRemoved = false;
-	 
-	  public FilePrefs(AbstractPreferences parent, String name) {
-	    super(parent, name);
-	 
-	    log.info("Instantiating node " + name);
-	 
-	    root = new TreeMap<String, String>();
-	    children = new TreeMap<String, FilePrefs>();
-	    children_names = new ArrayList<String>();
-	 
-	    try {
-	      sync();
-	    }
-	    catch (BackingStoreException e) {
-	      log.error("Unable to sync on creation of node " + name, e);
-	    }
-	  }
-	 
-	  synchronized protected void putSpi(String key, String value) {
-	    root.put(key, value);
-	    try {
-	      flush();
-	    }
-	    catch (BackingStoreException e) {
-	      log.error("Unable to flush after putting " + key, e);
-	    }
-	  }
-	 
-	  synchronized protected String getSpi(String key) {
-	    return root.get(key);
-	  }
-	 
-	  synchronized protected void removeSpi(String key) {
-	    root.remove(key);
-	    try {
-	      flush();
-	    }
-	    catch (BackingStoreException e) {
-	      log.error("Unable to flush after removing " + key, e);
-	    }
-	  }
-	 
-	  synchronized protected void removeNodeSpi() throws BackingStoreException {
-	    isRemoved = true;
-	    flush();
-	  }
-	 
-	  synchronized protected String[] keysSpi() throws BackingStoreException {
-	    return root.keySet().toArray(new String[root.keySet().size()]);
-	  }
-	 
-	  synchronized protected String[] childrenNamesSpi() throws BackingStoreException {
-		  return children_names.toArray(new String[children_names.size()]);
-	  }
-	 
-	  synchronized protected FilePrefs childSpi(String name) {
-	    FilePrefs child = children.get(name);
-	    if (child == null || child.isRemoved()) {
-	      child = new FilePrefs(this, name);
-	      children.put(name, child);
-	    }
-	    return child;
-	  }
-	 
-	 
-	  protected synchronized void syncSpi() throws BackingStoreException {
-		  
-		  if (isRemoved()) return;
+	private static final Logger log = LoggerFactory.getLogger(FilePrefs.class);
 
-		  final File file = FileBackingStorePrefsFactory.getPreferencesFile();
+	private Map<String, String> root;
+	private Map<String, FilePrefs> children;
+	private List<String> children_names;
+	private boolean isRemoved = false;
 
-		  if (!file.exists()) return;
+	public FilePrefs(AbstractPreferences parent, String name) {
+		super(parent, name);
 
-		  Properties p = new Properties();
-		  try {
-			  p.load(new FileInputStream(file));
+		log.info("Instantiating node " + name);
 
-			  StringBuilder sb = new StringBuilder();
-			  getPath(sb);
-			  String path = sb.toString();
+		root = new TreeMap<String, String>();
+		children = new TreeMap<String, FilePrefs>();
+		children_names = new ArrayList<String>();
 
-			  final Enumeration<?> pnen = p.propertyNames();
-			  while (pnen.hasMoreElements()) {
-				  String propKey = (String) pnen.nextElement();
-				  if (propKey.startsWith(path)) {
-					  String subKey = propKey.substring(path.length());
-					  // Only load immediate descendents
-					  if (subKey.indexOf('/') == -1) {
-						  root.put(subKey, p.getProperty(propKey));
-					  } else {
-						  children_names.add(subKey.substring(0,subKey.indexOf('/')));
-					  }
-				  }
-			  }
-		  }
-		  catch (IOException e) {
-			  throw new BackingStoreException(e);
-		  }
-	  }
-	  
-	 
-	  private void getPath(StringBuilder sb) {
-	    final FilePrefs parent = (FilePrefs) parent();
-	    if (parent == null) return;
-	 
-	    parent.getPath(sb);
-	    sb.append(name()).append('/');
-	  }
-	 
-	  protected synchronized void flushSpi() throws BackingStoreException {
-		  
-		  final File file = FileBackingStorePrefsFactory.getPreferencesFile();
-		  
-		  try {
+		try {
+			sync();
+		}
+		catch (BackingStoreException e) {
+			log.error("Unable to sync on creation of node " + name, e);
+		}
+	}
 
-			  StringBuilder sb = new StringBuilder();
-			  getPath(sb);
-			  String path = sb.toString();
-			  Properties p = new Properties();
-			  if (file.exists()) {
-				  
-				  p.load(new FileInputStream(file));
+	synchronized protected void putSpi(String key, String value) {
+		root.put(key, value);
+		try {
+			flush();
+		}
+		catch (BackingStoreException e) {
+			log.error("Unable to flush after putting " + key, e);
+		}
+	}
 
-				  List<String> toRemove = new ArrayList<String>();
+	synchronized protected String getSpi(String key) {
+		return root.get(key);
+	}
 
-				  // Make a list of all direct children of this node to be removed
-				  final Enumeration<?> pnen = p.propertyNames();
-				  while (pnen.hasMoreElements()) {
-					  String propKey = (String) pnen.nextElement();
-					  if (propKey.startsWith(path)) {
-						  String subKey = propKey.substring(path.length());
-						  // Only do immediate descendants
-						  if (subKey.indexOf('/') == -1) {
-							  toRemove.add(propKey);
-						  }
-					  }
-				  }
+	synchronized protected void removeSpi(String key) {
+		root.remove(key);
+		try {
+			flush();
+		}
+		catch (BackingStoreException e) {
+			log.error("Unable to flush after removing " + key, e);
+		}
+	}
 
-				  // Remove them now that the enumeration is done with
-				  for (String propKey : toRemove) {
-					  p.remove(propKey);
-				  }
+	synchronized protected void removeNodeSpi() throws BackingStoreException {
+		isRemoved = true;
+		flush();
+	}
+
+	synchronized protected String[] keysSpi() throws BackingStoreException {
+		return root.keySet().toArray(new String[root.keySet().size()]);
+	}
+
+	synchronized protected String[] childrenNamesSpi() throws BackingStoreException {
+		return children_names.toArray(new String[children_names.size()]);
+	}
+
+	synchronized protected FilePrefs childSpi(String name) {
+		FilePrefs child = children.get(name);
+		if (child == null || child.isRemoved()) {
+			child = new FilePrefs(this, name);
+			children.put(name, child);
+		}
+		return child;
+	}
 
 
-				  // If this node hasn't been removed, add back in any values
-				  if (!isRemoved) {
-					  for (String s : root.keySet()) {
-						  //System.out.println("Adding  " + s);
-						  p.setProperty(path + s, root.get(s));
-					  }
-				  }
-				  
-			  }
-			  if (p.size() > 0) {
-				  p.store(new FileOutputStream(file), "FilePreferences");
-			  } else {
-				  log.warn("what happened");
-				  p.store(new FileOutputStream(file), "FilePreferences");
-				  log.warn("wrote empty file");
-			  }
-		  }
-		  catch (IOException e) {
-			  throw new BackingStoreException(e);
-		  }
-	  }
+	protected synchronized void syncSpi() throws BackingStoreException {
+
+		if (isRemoved()) return;
+
+		final File file = FileBackingStorePrefsFactory.getPreferencesFile();
+
+		if (!file.exists()) return;
+
+		Properties p = new Properties();
+		try {
+			p.load(new FileInputStream(file));
+
+			StringBuilder sb = new StringBuilder();
+			getPath(sb);
+			String path = sb.toString();
+
+			final Enumeration<?> pnen = p.propertyNames();
+			while (pnen.hasMoreElements()) {
+				String propKey = (String) pnen.nextElement();
+				if (propKey.startsWith(path)) {
+					String subKey = propKey.substring(path.length());
+					// Only load immediate descendents
+					if (subKey.indexOf('/') == -1) {
+						root.put(subKey, p.getProperty(propKey));
+					} else {
+						children_names.add(subKey.substring(0,subKey.indexOf('/')));
+					}
+				}
+			}
+		}
+		catch (IOException e) {
+			throw new BackingStoreException(e);
+		}
+	}
+
+
+	private void getPath(StringBuilder sb) {
+		final FilePrefs parent = (FilePrefs) parent();
+		if (parent == null) return;
+
+		parent.getPath(sb);
+		sb.append(name()).append('/');
+	}
+
+	protected synchronized void flushSpi() throws BackingStoreException {
+
+		final File file = FileBackingStorePrefsFactory.getPreferencesFile();
+
+		try {
+
+			StringBuilder sb = new StringBuilder();
+			getPath(sb);
+			String path = sb.toString();
+			Properties p = new Properties();
+			if (file.exists()) {
+
+				p.load(new FileInputStream(file));
+
+				List<String> toRemove = new ArrayList<String>();
+
+				// Make a list of all direct children of this node to be removed
+				final Enumeration<?> pnen = p.propertyNames();
+				while (pnen.hasMoreElements()) {
+					String propKey = (String) pnen.nextElement();
+					if (propKey.startsWith(path)) {
+						String subKey = propKey.substring(path.length());
+						// Only do immediate descendants
+						if (subKey.indexOf('/') == -1) {
+							toRemove.add(propKey);
+						}
+					}
+				}
+
+				// Remove them now that the enumeration is done with
+				for (String propKey : toRemove) {
+					p.remove(propKey);
+				}
+
+
+				// If this node hasn't been removed, add back in any values
+				if (!isRemoved) {
+					for (String s : root.keySet()) {
+						//System.out.println("Adding  " + s);
+						p.setProperty(path + s, root.get(s));
+					}
+				}
+
+			}
+			if (p.size() > 0) {
+				p.store(new FileOutputStream(file), "FilePreferences");
+			} else {
+				log.warn("what happened");
+				p.store(new FileOutputStream(file), "FilePreferences");
+				log.warn("wrote empty file");
+			}
+		}
+		catch (IOException e) {
+			throw new BackingStoreException(e);
+		}
+	}
 
 }

--- a/protege-launcher/src/main/java/org/protege/prefs/FilePrefs.java
+++ b/protege-launcher/src/main/java/org/protege/prefs/FilePrefs.java
@@ -103,19 +103,17 @@ public class FilePrefs extends AbstractPreferences {
 			StringBuilder sb = new StringBuilder();
 			getPath(sb);
 			String path = sb.toString();
-
-			final Enumeration<?> pnen = p.propertyNames();
-			while (pnen.hasMoreElements()) {
-				String propKey = (String) pnen.nextElement();
-				if (propKey.startsWith(path)) {
-					String subKey = propKey.substring(path.length());
-					// Only load immediate descendents
-					if (subKey.indexOf('/') == -1) {
-						root.put(subKey, p.getProperty(propKey));
-					} else {
-						children_names.add(subKey.substring(0,subKey.indexOf('/')));
-					}
-				}
+			
+			List<String> propKeys = getPropNamesWithPrefix(p, path);
+			
+			for(String propKey : propKeys) {
+				String subKey = propKey.substring(path.length());
+				// Only load immediate descendents
+				if (subKey.indexOf('/') == -1) {
+					root.put(subKey, p.getProperty(propKey));
+				} else {
+					children_names.add(subKey.substring(0,subKey.indexOf('/')));
+				}				
 			}
 		}
 		catch (IOException e) {
@@ -147,18 +145,15 @@ public class FilePrefs extends AbstractPreferences {
 				p.load(new FileInputStream(file));
 
 				List<String> toRemove = new ArrayList<String>();
-
-				// Make a list of all direct children of this node to be removed
-				final Enumeration<?> pnen = p.propertyNames();
-				while (pnen.hasMoreElements()) {
-					String propKey = (String) pnen.nextElement();
-					if (propKey.startsWith(path)) {
-						String subKey = propKey.substring(path.length());
-						// Only do immediate descendants
-						if (subKey.indexOf('/') == -1) {
-							toRemove.add(propKey);
-						}
-					}
+				
+				List<String> propKeys = getPropNamesWithPrefix(p, path);
+				
+				for(String propKey : propKeys) {
+					String subKey = propKey.substring(path.length());
+					// Only do immediate descendants
+					if (subKey.indexOf('/') == -1) {
+						toRemove.add(propKey);
+					}					
 				}
 
 				// Remove them now that the enumeration is done with
@@ -188,5 +183,19 @@ public class FilePrefs extends AbstractPreferences {
 			throw new BackingStoreException(e);
 		}
 	}
-
+	
+	private static List<String> getPropNamesWithPrefix(Properties p, String path) {
+		
+		List<String> names = new ArrayList<String>();
+		
+		// Make a list of all direct children of this node to be removed
+		final Enumeration<?> pnen = p.propertyNames();
+		while (pnen.hasMoreElements()) {
+			String propKey = (String) pnen.nextElement();
+			if (propKey.startsWith(path)) {
+				names.add(propKey);
+			}
+		}
+		return names;		
+	}
 }

--- a/protege-launcher/src/test/java/org/protege/prefs/FileBasedPrefsTest.java
+++ b/protege-launcher/src/test/java/org/protege/prefs/FileBasedPrefsTest.java
@@ -1,0 +1,127 @@
+package org.protege.prefs;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import org.junit.Test;
+
+public class FileBasedPrefsTest {
+	static {
+		System.setProperty("java.util.prefs.PreferencesFactory", "org.protege.prefs.FileBackingStorePrefsFactory");
+	}
+	
+	@Test
+	public void testRoot() {
+		Preferences root = Preferences.userRoot();
+		assert(root instanceof Preferences);
+	}
+	
+	@Test
+	public void addNode() {
+		Preferences root = Preferences.userRoot();
+		Preferences foo = root.node("foo");
+		foo.put("foo", "foo1");
+		assert(foo.get("foo", "bad").equals("foo1"));		
+	}
+	
+	@Test
+	public void addInt() {
+		Preferences root = Preferences.userRoot();
+		Preferences foo = root.node("foo");
+		foo.putInt("foo", 57);
+		assert(foo.getInt("foo", 59) == 57);		
+	}
+	
+	@Test
+	public void clearNode() {
+		Preferences root = Preferences.userRoot();
+		Preferences foo = root.node("foo");
+		foo.put("foo", "foo1");
+		assert(foo.get("foo", "bad").equals("foo1"));
+		try {
+			foo.clear();
+			assert(foo.get("foo", "bad").equals("bad"));
+		} catch (BackingStoreException e) {
+			e.printStackTrace();
+			assert(false);			
+		}		
+	}
+	
+	@Test
+	public void removeNode() {
+		Preferences root = Preferences.userRoot();
+		Preferences foo = root.node("foo");
+		foo.put("foo", "foo1");
+		assert(foo.get("foo", "bad").equals("foo1"));
+		try {
+			foo.removeNode();
+			root.flush();
+			assert(root.childrenNames().length == 0);			
+		} catch (BackingStoreException e) {
+			e.printStackTrace();
+			assert(false);			
+		}		
+	}
+	
+	@Test
+	public void addLists() {
+		Preferences root = Preferences.userRoot();
+
+		List<String> foos = new ArrayList<String>();
+		foos.add("bob");
+		foos.add("dodo");
+		foos.add("yinghua");
+		foos.add("gilberto");
+		foos.add("rudi");
+
+		putStringList(root, "foo", foos);
+
+		List<String> foosList = this.getStringList(root, "foo", new ArrayList<String>());
+
+		assert(foosList.size() == 5);
+		assert(foosList.contains("dodo"));
+		assert(foosList.contains("bob"));
+		assert(foosList.contains("yinghua"));
+		assert(foosList.contains("gilberto"));
+		assert(foosList.contains("rudi"));	
+
+	}
+	
+	
+	private Preferences getList(Preferences root, String listKey, boolean create) {
+        try {
+            if (create || root.nodeExists(listKey)){
+                return root.node(listKey);
+            }
+        }
+        catch (BackingStoreException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    private List<String> getStringList(Preferences root, String key, List<String> def) {
+        Preferences listPrefs = getList(root, key, false);
+        if (listPrefs == null){
+            return def;
+        }
+        int size = listPrefs.getInt("listSize", 0);
+        List<String> list = new ArrayList<>();
+        for(int i = 0; i < size; i++) {
+            list.add(listPrefs.get(Integer.toString(i), ""));
+        }
+        return list;
+    }
+
+
+    private void putStringList(Preferences root, String key, List<String> val) {
+        Preferences listPrefs = getList(root, key, true);
+        listPrefs.putInt("listSize", val.size());
+        for(int i = 0; i < val.size(); i++) {
+            listPrefs.put(Integer.toString(i), val.get(i));
+        }
+    }
+
+}


### PR DESCRIPTION
This provides better control over where preferences are stored. The default implementation punts
to the OS which means on different platforms they are stored in different places. To use specify the
following system property, -Djava.util.prefs.PreferencesFactory=org.protege.prefs.FileBackingStorePrefsFactory
when starting the VM. The default location is .fileprefs in the directory the app is run from. To change
use the system property -Dorg.protege.prefs.PrefsFactory.file=<yourfilename>