### PR TITLE
Catch notworkflow manager error and show to user

### DIFF
--- a/protege-common/src/main/java/org/protege/common/NotWorkflowManager.java
+++ b/protege-common/src/main/java/org/protege/common/NotWorkflowManager.java
@@ -1,0 +1,4 @@
+package org.protege.common;
+
+public class NotWorkflowManager extends RuntimeException {
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OWLWorkspace.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OWLWorkspace.java
@@ -5,6 +5,7 @@ import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IRegistryEventListener;
+import org.protege.common.NotWorkflowManager;
 import org.protege.editor.core.Fonts;
 import org.protege.editor.core.ProtegeApplication;
 import org.protege.editor.core.ProtegeManager;
@@ -134,6 +135,9 @@ public class OWLWorkspace extends TabbedWorkspace implements SendErrorReportHand
 				if (pelletRestartCallback.isPresent()) {
 					try {
 						pelletRestartCallback.get().call();
+					} catch (NotWorkflowManager e1) {
+						JOptionPane.showMessageDialog(null,
+							"You must be a workflow manager to restart pellet");
 					} catch (Exception e1) {
 						throw new RuntimeException(e1);
 					}


### PR DESCRIPTION
@AnthonyMl it looks like you can show a message dialog anywhere just by passing
null where it usually expects a frame.